### PR TITLE
Added documentation generation for the specified plugin project

### DIFF
--- a/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
+++ b/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
@@ -202,9 +202,11 @@ public class JavadocMojo extends AbstractMojo {
         runner.setDocletArtifactsResolver(docletArtifactsResolver);
 
         final GatherManifestVisitor gmv = new GatherManifestVisitor();
+        gmv.visit(this.session.getCurrentProject());
         visitProjects(this.session.getCurrentProject().getDependencies(), this.scopes, gmv);
 
         final GatherSourcesVisitor gsv = new GatherSourcesVisitor();
+        gsv.visit(this.session.getCurrentProject());
         visitProjects(this.session.getCurrentProject().getDependencies(), this.scopes, gsv);
 
         getLog().info(String.format("%s source folders", gsv.getSourceFolders().size()));


### PR DESCRIPTION
The documentation of the specified plugin project wasn't generated with the actual version on my side. Here is a patch proposal that allow to generate this documentation.